### PR TITLE
Fix product sub_menu display on new Solidus

### DIFF
--- a/app/views/spree/admin/parts/index.html.erb
+++ b/app/views/spree/admin/parts/index.html.erb
@@ -1,5 +1,5 @@
 <%# This partial was remove in solidus 1.2 but that is also when Spree.solidus_version was added %>
-<%= render :partial => 'spree/admin/shared/product_sub_menu' if !spree.respond_to?(:solidus_version) %>
+<%= render :partial => 'spree/admin/shared/product_sub_menu' if !Spree.respond_to?(:solidus_version) %>
 
 <%= render :partial => 'spree/admin/shared/product_tabs', :locals => {:current => "Parts"} %>
 <div id="product_parts">


### PR DESCRIPTION
`solidus_version` is a class method not an instance method, this was showing the sub_menu on *all* versions of Solidus, not just the oldest ones as intended.