### PR TITLE
Fix a load order issue when redefining inventory validator.

### DIFF
--- a/app/models/spree/stock/inventory_validator_decorator.rb
+++ b/app/models/spree/stock/inventory_validator_decorator.rb
@@ -1,16 +1,12 @@
-module Spree
-  module Stock
-    class InventoryValidator < ActiveModel::Validator
-      def validate(line_item)
-        total_quantity = line_item.quantity_by_variant.values.sum
+Spree::Stock::InventoryValidator.class_eval do
+  def validate(line_item)
+    total_quantity = line_item.quantity_by_variant.values.sum
 
-        if line_item.inventory_units.count != total_quantity
-          line_item.errors[:inventory] << Spree.t(
-              :inventory_not_available,
-              item: line_item.variant.name
-          )
-        end
-      end
+    if line_item.inventory_units.count != total_quantity
+      line_item.errors[:inventory] << Spree.t(
+        :inventory_not_available,
+        item: line_item.variant.name
+      )
     end
   end
 end


### PR DESCRIPTION
On cached environments, when redefining the class, the original method
is what is defined. We're not entirely sure why, but this should be
class eval'd anyway instead of redefining the class.