### PR TITLE
Add missing translation for actions.delete

### DIFF
--- a/app/views/spree/admin/orders/_stock_item.html.erb
+++ b/app/views/spree/admin/orders/_stock_item.html.erb
@@ -38,7 +38,7 @@
           <%= link_to '', '#', :class => 'cancel-item fa fa-cancel no-text with-tip', :data => {:action => 'cancel'}, :title => Spree.t('actions.cancel'), :style => 'display: none' %>
           <%= link_to '', '#', :class => 'edit-item fa fa-edit no-text with-tip', :data => {:action => 'edit'}, :title => Spree.t('edit') %>
           <%= link_to '', '#', :class => 'split-item fa fa-arrows-h no-text with-tip', :data => {:action => 'split', 'variant-id' => item.variant.id}, :title => Spree.t('split') %>
-          <%= link_to '', '#', :class => 'delete-item fa fa-trash no-text with-tip', :data => {'shipment-number' => shipment.number, 'variant-id' => item.variant.id, :action => 'remove'}, :title => Spree.t('delete') %>
+          <%= link_to '', '#', :class => 'delete-item fa fa-trash no-text with-tip', :data => {'shipment-number' => shipment.number, 'variant-id' => item.variant.id, :action => 'remove'}, :title => Spree.t('actions.delete') %>
         <% end %>
       <% end %>
     </td>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,3 +10,5 @@ en:
     product_bundles: Product Bundles
     parts_included: Parts included
     part_of_bundle: 'Part of bundle %{sku}'
+    actions:
+      delete: 'Delete'


### PR DESCRIPTION
This translation was new to Solidus 1.3, I think it's easiest to just
backfill here to prevent Spree.t from inserting a span which breaks html
when used inside of a tag attribute

eg: title="<span class="translation_missing