### PR TITLE
Parts informations in API

### DIFF
--- a/app/views/spree/api/line_items/show.v1.rabl
+++ b/app/views/spree/api/line_items/show.v1.rabl
@@ -1,0 +1,26 @@
+object @line_item
+cache [I18n.locale, root_object]
+attributes *line_item_attributes
+node(:single_display_amount) { |li| li.single_display_amount.to_s }
+node(:display_amount) { |li| li.display_amount.to_s }
+node(:total) { |li| li.total }
+glue :variant => :parts do
+  glue :product do
+    child :parts => :parts do
+      extends "spree/api/variants/small"
+      attributes :product_id
+
+      child(:images => :images) { extends "spree/api/images/show" }
+    end
+
+  end
+end
+child :variant do
+  extends "spree/api/variants/small"
+  attributes :product_id
+  child(:images => :images) { extends "spree/api/images/show" }
+end
+
+child :adjustments => :adjustments do
+  extends "spree/api/adjustments/show"
+end


### PR DESCRIPTION
Line items don't provide informations about parts through API views.
Add parts informations. Now the result json is:

line_item:
  variant:
    variant attributes...
  parts:
    0:
      variant attributes...
    1:
      variant attributes...
