### PR TITLE
Fix deprecations and removals

### DIFF
--- a/app/controllers/spree/admin/parts_controller.rb
+++ b/app/controllers/spree/admin/parts_controller.rb
@@ -1,5 +1,5 @@
 class Spree::Admin::PartsController < Spree::Admin::BaseController
-  before_filter :find_product
+  before_action :find_product
 
   def index
     @parts = @product.parts

--- a/app/controllers/spree/admin/parts_controller.rb
+++ b/app/controllers/spree/admin/parts_controller.rb
@@ -22,8 +22,7 @@ class Spree::Admin::PartsController < Spree::Admin::BaseController
       @available_products = []
     else
       query = "%#{params[:q]}%"
-      @available_products = Spree::Product.search_can_be_part(query)
-      @available_products.uniq!
+      @available_products = Spree::Product.search_can_be_part(query).distinct
     end
     respond_to do |format|
       format.html {render :layout => false}

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -1,6 +1,6 @@
 module Spree
   LineItem.class_eval do
-    scope :assemblies, -> { joins(:product => :parts).uniq }
+    scope :assemblies, -> { joins(:product => :parts).distinct }
 
     def any_units_shipped?
       inventory_units.any? { |unit| unit.shipped? }

--- a/app/views/spree/admin/orders/_stock_item.html.erb
+++ b/app/views/spree/admin/orders/_stock_item.html.erb
@@ -1,6 +1,6 @@
 <% shipment.manifest.each do |item| %>
   <tr class="stock-item" data-item-quantity="<%= item.quantity %>">
-    <td class="item-image"><%= mini_image(item.variant) %></td>
+    <td class="item-image"><%= image_tag item.variant.display_image.attachment(:mini) %></td>
     <td class="item-name">
       <%= item.variant.product.name %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>
       <% if item.part && item.line_item %>

--- a/app/views/spree/checkout/_line_item_manifest.html.erb
+++ b/app/views/spree/checkout/_line_item_manifest.html.erb
@@ -1,6 +1,6 @@
 <% ship_form.object.line_item_manifest.each do |item| %>
   <tr class="stock-item">
-    <td class="item-image"><%= mini_image(item.variant) %></td>
+    <td class="item-image"><%= image_tag item.variant.display_image.attachment(:mini) %></td>
     <td class="item-name">
       <%= item.variant.name %>
       <%= render 'spree/orders/cart_description', variant: item.variant, line_item: item.line_item %>


### PR DESCRIPTION
This fixes an error on Solidus >= 2.1, where we've removed `mini_image`