### PR TITLE
Remove old Spree information from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,6 @@ append solidus_product_assembly to your js manifest file
     bundle install
     rails g solidus_product_assembly:install
 
-_master branch is compatible with spree edge and rails 4 only. Please use
-2-0-stable for Spree 2.0.x or 1-3-stable branch for Spree 1.3.x compatibility_
-
-_In case you're upgrading from 1-3-stable of this extension you might want to run a
-rake task which assigns a line item to your previous inventory units from bundle
-products. That is so you have a better view on the current backend UI and avoid
-exceptions. No need to run this task if you're not upgrading from product assembly
-1-3-stable_
-
-    rake solidus_product_assembly:upgrade
-
 ## Use
 
 To build a bundle (assembly product) you'd need to first check the "Can be part"


### PR DESCRIPTION
The README contained old information pertaining to old versions of Spree. For instance, it referred to a `2-0-stable` branch which does not exist in the current repository. It also included references to a migration from Spree 2.0 and earlier, but the Solidus fork begins at Spree 2.4, so I believe this is no longer necessary.