### PR TITLE
Update for Solidus 2.5

### DIFF
--- a/app/models/spree/stock/inventory_unit_builder_decorator.rb
+++ b/app/models/spree/stock/inventory_unit_builder_decorator.rb
@@ -10,6 +10,14 @@ module Spree
       end
 
       def build_inventory_unit(variant, line_item)
+        inventory_unit_attributes = {
+          pending: true,
+          variant: variant,
+          line_item: line_item,
+        }
+        if SolidusSupport.solidus_gem_version < Gem::Version.new('2.5.x')
+          inventory_unit_attributes[:order] = @order
+        end
         @order.inventory_units.includes(
           variant: {
             product: {
@@ -18,12 +26,7 @@ module Spree
               }
             }
           }
-        ).build(
-          pending: true,
-          variant: variant,
-          line_item: line_item,
-          order: @order
-        )
+        ).build(inventory_unit_attributes)
       end
     end
   end

--- a/spec/models/spree/inventory_unit_spec.rb
+++ b/spec/models/spree/inventory_unit_spec.rb
@@ -5,10 +5,16 @@ module Spree
     let!(:order) { create(:order_with_line_items) }
     let(:line_item) { order.line_items.first }
     let(:product) { line_item.product }
+    let(:shipment) { create(:shipment, order: order) }
 
-    subject { InventoryUnit.create(line_item: line_item, variant: line_item.variant, order: order) }
+    if SolidusSupport.solidus_gem_version < Gem::Version.new('2.5.x')
+      let(:attributes) { { shipment: shipment, line_item: line_item, variant: line_item.variant, order: order } }
+    else
+      let(:attributes) { { shipment: shipment, line_item: line_item, variant: line_item.variant } }
+    end
+    subject { InventoryUnit.create!(attributes) }
 
-    context 'if the unit is not part of an assembly' do      
+    context 'if the unit is not part of an assembly' do
       it 'it will return the percentage of a line item' do
         expect(subject.percentage_of_line_item).to eql(BigDecimal.new(1))
       end

--- a/spec/models/spree/shipment_spec.rb
+++ b/spec/models/spree/shipment_spec.rb
@@ -55,7 +55,7 @@ module Spree
       let(:line_item) { create(:line_item) }
       let(:variant) { line_item.variant }
       let(:order) { line_item.order }
-      let(:shipment) { create(:shipment) }
+      let(:shipment) { create(:shipment, order: order) }
 
       it "assigns variant, order and line_item" do
         unit = shipment.set_up_inventory('on_hand', variant, order, line_item)

--- a/spec/models/spree/stock/inventory_unit_builder_spec.rb
+++ b/spec/models/spree/stock/inventory_unit_builder_spec.rb
@@ -24,10 +24,6 @@ module Spree
             it "builds the inventory units as pending" do
               expect(subject.units.map(&:pending).uniq).to eq [true]
             end
-
-            it "associates the inventory units to the order" do
-              expect(subject.units.map(&:order).uniq).to eq [order]
-            end
           end
         end
       end


### PR DESCRIPTION
Solidus 2.5 removes the order association from inventory units, so we
need to check what version we're on and act accordingly.