### PR TITLE
 AvailabilityValidator delegates to Solidus implementation when product is not an assembly

### DIFF
--- a/app/decorators/models/spree/stock/availability_validator_decorator.rb
+++ b/app/decorators/models/spree/stock/availability_validator_decorator.rb
@@ -1,25 +1,29 @@
+
 module Spree
   module Stock
     # Overridden from spree core to make it also check for assembly parts stock
     module AvailabilityValidatorDecorator
       def validate(line_item)
-        line_item.quantity_by_variant.each do |variant, variant_quantity|
-          inventory_units = line_item.inventory_units.where(variant: variant).count
-          quantity = variant_quantity - inventory_units
+        unless line_item.product.assembly?
+          super
+        else
+          line_item.quantity_by_variant.each do |variant, variant_quantity|
+            inventory_units = line_item.inventory_units.where(variant: variant).count
+            quantity = variant_quantity - inventory_units
+            next if quantity <= 0
+            next unless variant
 
-          next if quantity <= 0
-          next unless variant
+            quantifier = Stock::Quantifier.new(variant)
 
-          quantifier = Stock::Quantifier.new(variant)
+            unless quantifier.can_supply? quantity
+              display_name = %Q{#{variant.name}}
+              display_name += %Q{ (#{variant.options_text})} unless variant.options_text.blank?
 
-          unless quantifier.can_supply? quantity
-            display_name = %Q{#{variant.name}}
-            display_name += %Q{ (#{variant.options_text})} unless variant.options_text.blank?
-
-            line_item.errors[:quantity] << I18n.t(
-              'spree.selected_quantity_not_available',
-              item: display_name.inspect
-            )
+              line_item.errors[:quantity] << I18n.t(
+                'spree.selected_quantity_not_available',
+                item: display_name.inspect
+              )
+            end
           end
         end
       end

--- a/app/decorators/models/spree/stock/availability_validator_decorator.rb
+++ b/app/decorators/models/spree/stock/availability_validator_decorator.rb
@@ -1,7 +1,7 @@
 module Spree
   module Stock
     # Overridden from spree core to make it also check for assembly parts stock
-    class AvailabilityValidator < ActiveModel::Validator
+    module AvailabilityValidatorDecorator
       def validate(line_item)
         line_item.quantity_by_variant.each do |variant, variant_quantity|
           inventory_units = line_item.inventory_units.where(variant: variant).count
@@ -23,6 +23,8 @@ module Spree
           end
         end
       end
+
+      Spree::Stock::AvailabilityValidator.prepend self
     end
   end
 end

--- a/spec/models/spree/stock/availability_validator_spec.rb
+++ b/spec/models/spree/stock/availability_validator_spec.rb
@@ -9,22 +9,8 @@ module Spree
 
         subject { described_class.new }
 
-        it 'should be valid when supply is sufficient' do
-          allow_any_instance_of(Stock::Quantifier).to receive(:can_supply?).and_return(true)
-          expect(line_item).not_to receive(:errors)
-          subject.validate(line_item)
-        end
-
-        it 'should be invalid when supply is insufficent' do
-          allow_any_instance_of(Stock::Quantifier).to receive(:can_supply?).and_return(false)
-          expect(line_item.errors).to receive(:[]).exactly(1).times.with(:quantity).and_return([])
-          subject.validate(line_item)
-        end
-
-        it 'should consider existing inventory_units sufficient' do
-          allow_any_instance_of(Stock::Quantifier).to receive(:can_supply?).and_return(false)
-          allow(line_item.inventory_units).to receive(:where).and_return([double] * 5)
-          expect(line_item).not_to receive(:errors)
+        it 'delegates to the original Solidus implementation' do
+          expect(subject).to receive(:is_valid?).with(line_item)
           subject.validate(line_item)
         end
       end


### PR DESCRIPTION
When validating line items for products that are not assemblies, we should delegate to the original Solidus implementation.