### PR TITLE
Fix admin edit for shipping costs and tracking

### DIFF
--- a/app/overrides/spree/admin/orders/_shipment/stock_contents.html.erb.deface
+++ b/app/overrides/spree/admin/orders/_shipment/stock_contents.html.erb.deface
@@ -1,2 +1,8 @@
 <!-- replace_contents  '.stock-contents tbody' -->
-<%= render 'stock_contents', shipment: shipment %>
+<% if Spree.solidus_gem_version < Gem::Version.new('2.4') %>
+  <%= render "stock_contents_2_3", shipment: shipment %>
+<% elsif Spree.solidus_gem_version < Gem::Version.new('2.5') %>
+  <%= render "stock_contents_2_4", shipment: shipment %>
+<% else %>
+  <%= render "stock_contents", shipment: shipment %>
+<% end %>

--- a/app/views/spree/admin/orders/_stock_contents.html.erb
+++ b/app/views/spree/admin/orders/_stock_contents.html.erb
@@ -1,69 +1,9 @@
 <%= render 'stock_item', shipment: shipment %>
 
 <% unless shipment.shipped? %>
-  <tr class="edit-method hidden total">
-    <td colspan="5">
-      <div class="field alpha five columns">
-        <%= label_tag 'selected_shipping_rate_id', I18n.t('spree.shipping_method') %>
-        <%= select_tag :selected_shipping_rate_id,
-              options_for_select(shipment.shipping_rates.map {|sr| ["#{sr.name} #{sr.display_price}", sr.id] }, shipment.selected_shipping_rate_id),
-              {:class => 'select2 fullwidth', :data => {'shipment-number' => shipment.number } } %>
-      </div>
-    </td>
-    <td class="actions">
-      <% if can? :update, shipment %>
-        <%= link_to '', '#', :class => 'save-method fa fa-ok no-text with-tip',
-          :data => {'shipment-number' => shipment.number, :action => 'save'}, title: I18n.t('spree.actions.save') %>
-        <%= link_to '', '#', :class => 'cancel-method fa fa-cancel no-text with-tip',
-          :data => {:action => 'cancel'}, :title => I18n.t('spree.actions.cancel') %>
-      <% end %>
-    </td>
+  <tr class="edit-shipping-method vertical-middle">
   </tr>
 <% end %>
 
-<tr class="show-method total">
-  <% if shipment.shipping_method %>
-    <td colspan="4">
-      <strong><%= shipment.shipping_method.name %></strong>
-    </td>
-    <td class="total" align="center">
-      <span><%= shipment.display_cost %></span>
-    </td>
-  <% else %>
-    <td colspan='5'><%= I18n.t('spree.no_shipping_method_selected') %></td>
-  <% end %>
-
-  <td class="actions">
-    <% if can? :update, shipment %>
-      <%= link_to '', '#', :class => 'edit-method fa fa-edit no-text with-tip', :data => {:action => 'edit'}, :title => I18n.t('spree.actions.edit') %>
-    <% end %>
-  </td>
-</tr>
-
-<tr class="edit-tracking hidden total">
-  <td colspan="5">
-    <label><%= I18n.t('spree.tracking_number') %>:</label>
-    <%= text_field_tag :tracking, shipment.tracking %>
-  </td>
-  <td class="actions">
-    <% if can? :update, shipment %>
-      <%= link_to '', '#', :class => 'save-tracking fa fa-ok no-text with-tip', :data => {'shipment-number' => shipment.number, :action => 'save'}, :title => I18n.t('spree.actions.save') %>
-      <%= link_to '', '#', :class => 'cancel-tracking fa fa-cancel no-text with-tip', :data => {:action => 'cancel'}, :title => I18n.t('spree.actions.cancel') %>
-    <% end %>
-  </td>
-</tr>
-
-<tr class="show-tracking total">
-  <td colspan="5">
-    <% if shipment.tracking.present? %>
-      <strong><%= I18n.t('spree.tracking') %>:</strong> <%= shipment.tracking %>
-    <% else %>
-      <%= I18n.t('spree.no_tracking_present') %>
-    <% end %>
-  </td>
-  <td class="actions">
-    <% if can? :update, shipment %>
-      <%= link_to '', '#', :class => 'edit-tracking fa fa-edit no-text with-tip', :data => {:action => 'edit'}, :title => I18n.t('spree.actions.edit') %>
-    <% end %>
-  </td>
+<tr class="edit-tracking vertical-middle">
 </tr>

--- a/app/views/spree/admin/orders/_stock_contents_2_3.html.erb
+++ b/app/views/spree/admin/orders/_stock_contents_2_3.html.erb
@@ -1,0 +1,69 @@
+<%= render 'stock_item', shipment: shipment %>
+
+<% unless shipment.shipped? %>
+  <tr class="edit-method hidden total">
+    <td colspan="5">
+      <div class="field alpha five columns">
+        <%= label_tag 'selected_shipping_rate_id', I18n.t('spree.shipping_method') %>
+        <%= select_tag :selected_shipping_rate_id,
+              options_for_select(shipment.shipping_rates.map {|sr| ["#{sr.name} #{sr.display_price}", sr.id] }, shipment.selected_shipping_rate_id),
+              {:class => 'select2 fullwidth', :data => {'shipment-number' => shipment.number } } %>
+      </div>
+    </td>
+    <td class="actions">
+      <% if can? :update, shipment %>
+        <%= link_to '', '#', :class => 'save-method fa fa-ok no-text with-tip',
+          :data => {'shipment-number' => shipment.number, :action => 'save'}, title: I18n.t('spree.actions.save') %>
+        <%= link_to '', '#', :class => 'cancel-method fa fa-cancel no-text with-tip',
+          :data => {:action => 'cancel'}, :title => I18n.t('spree.actions.cancel') %>
+      <% end %>
+    </td>
+  </tr>
+<% end %>
+
+<tr class="show-method total">
+  <% if shipment.shipping_method %>
+    <td colspan="4">
+      <strong><%= shipment.shipping_method.name %></strong>
+    </td>
+    <td class="total" align="center">
+      <span><%= shipment.display_cost %></span>
+    </td>
+  <% else %>
+    <td colspan='5'><%= I18n.t('spree.no_shipping_method_selected') %></td>
+  <% end %>
+
+  <td class="actions">
+    <% if can? :update, shipment %>
+      <%= link_to '', '#', :class => 'edit-method fa fa-edit no-text with-tip', :data => {:action => 'edit'}, :title => I18n.t('spree.actions.edit') %>
+    <% end %>
+  </td>
+</tr>
+
+<tr class="edit-tracking hidden total">
+  <td colspan="5">
+    <label><%= I18n.t('spree.tracking_number') %>:</label>
+    <%= text_field_tag :tracking, shipment.tracking %>
+  </td>
+  <td class="actions">
+    <% if can? :update, shipment %>
+      <%= link_to '', '#', :class => 'save-tracking fa fa-ok no-text with-tip', :data => {'shipment-number' => shipment.number, :action => 'save'}, :title => I18n.t('spree.actions.save') %>
+      <%= link_to '', '#', :class => 'cancel-tracking fa fa-cancel no-text with-tip', :data => {:action => 'cancel'}, :title => I18n.t('spree.actions.cancel') %>
+    <% end %>
+  </td>
+</tr>
+
+<tr class="show-tracking total">
+  <td colspan="5" class="tracking-value">
+    <% if shipment.tracking.present? %>
+      <%= shipment.tracking %>
+    <% else %>
+      <%= I18n.t('spree.no_tracking_present') %>
+    <% end %>
+  </td>
+  <td class="actions">
+    <% if can? :update, shipment %>
+      <%= link_to '', '#', :class => 'edit-tracking fa fa-edit no-text with-tip', :data => {:action => 'edit'}, :title => I18n.t('spree.actions.edit') %>
+    <% end %>
+  </td>
+</tr>

--- a/app/views/spree/admin/orders/_stock_contents_2_4.html.erb
+++ b/app/views/spree/admin/orders/_stock_contents_2_4.html.erb
@@ -1,0 +1,70 @@
+<%= render 'stock_item', shipment: shipment %>
+
+<% unless shipment.shipped? %>
+  <tr class="edit-method hidden total">
+    <td colspan="5">
+      <div class="field alpha five columns">
+        <%= label_tag 'selected_shipping_rate_id', I18n.t('spree.shipping_method') %>
+        <%= select_tag :selected_shipping_rate_id,
+              options_for_select(shipment.shipping_rates.map {|sr| ["#{sr.name} #{sr.display_price}", sr.id] }, shipment.selected_shipping_rate_id),
+              {:class => 'select2 fullwidth', :data => {'shipment-number' => shipment.number } } %>
+      </div>
+    </td>
+    <td class="actions">
+      <% if can? :update, shipment %>
+        <%= button_tag '', :class => 'save-method fa fa-ok no-text with-tip',
+          :data => {'shipment-number' => shipment.number, :action => 'save'}, title: I18n.t('spree.actions.save') %>
+        <%= button_tag '', :class => 'cancel-method fa fa-cancel no-text with-tip',
+          :data => {:action => 'cancel'}, :title => I18n.t('spree.actions.cancel') %>
+      <% end %>
+    </td>
+  </tr>
+<% end %>
+
+<tr class="show-method total">
+  <% if shipment.shipping_method %>
+    <td colspan="4">
+      <strong><%= shipment.shipping_method.name %></strong>
+    </td>
+    <td class="total" align="center">
+      <span><%= shipment.display_cost %></span>
+    </td>
+  <% else %>
+    <td colspan='5'><%= I18n.t('spree.no_shipping_method_selected') %></td>
+  <% end %>
+
+  <td class="actions">
+    <% if can? :update, shipment %>
+      <%= button_tag '', :class => 'edit-method fa fa-edit no-text with-tip', :data => {:action => 'edit'}, :title => I18n.t('spree.actions.edit') %>
+    <% end %>
+  </td>
+</tr>
+
+<tr class="edit-tracking hidden total">
+  <td colspan="5">
+    <label><%= I18n.t('spree.tracking_number') %>:</label>
+    <%= text_field_tag :tracking, shipment.tracking %>
+  </td>
+  <td class="actions">
+    <% if can? :update, shipment %>
+      <%= button_tag '', :class => 'save-tracking fa fa-ok no-text with-tip', :data => {'shipment-number' => shipment.number, :action => 'save'}, :title => I18n.t('spree.actions.save') %>
+      <%= button_tag '', :class => 'cancel-tracking fa fa-cancel no-text with-tip', :data => {:action => 'cancel'}, :title => I18n.t('spree.actions.cancel') %>
+    <% end %>
+  </td>
+</tr>
+
+<tr class="show-tracking total">
+  <th><%= Spree::Shipment.human_attribute_name(:tracking) %></th>
+  <td colspan="4" class="tracking-value">
+    <% if shipment.tracking.present? %>
+      <%= shipment.tracking %>
+    <% else %>
+      <i><%= Spree.t(:no_tracking_present) %></i>
+    <% end %>
+  </td>
+  <td class="actions">
+    <% if can? :update, shipment %>
+      <%= button_tag '', class: 'edit-tracking fa fa-edit no-text with-tip', data: {action: 'edit'}, title: Spree.t('actions.edit'), type: :button %>
+    <% end %>
+  </td>
+</tr>

--- a/spec/features/admin/orders_spec.rb
+++ b/spec/features/admin/orders_spec.rb
@@ -12,7 +12,7 @@ describe "Orders", type: :feature, js: true do
     bundle.parts << [parts]
     line_item.update_attributes!(quantity: 3)
     order.reload.create_proposed_shipments
-    order.finalize! 
+    order.finalize!
   end
 
   it "allows admin to edit product bundle" do
@@ -24,6 +24,85 @@ describe "Orders", type: :feature, js: true do
       find(".save-line-item").click
 
       sleep(1) # avoid odd "cannot rollback - no transaction is active: rollback transaction"
+    end
+  end
+
+  if Spree.solidus_gem_version < Gem::Version.new('2.5')
+    context 'Adding tracking number' do
+      let(:tracking_number) { 'AA123' }
+
+      before { visit spree.edit_admin_order_path(order) }
+
+      it 'allows admin to edit tracking' do
+        expect(page).not_to have_content tracking_number
+        within '.show-tracking' do
+          find('.fa-edit').click
+        end
+        within '.edit-tracking' do
+          expect(page).to have_selector 'input[name="tracking"]'
+          fill_in :tracking, with: tracking_number
+          find('.fa-ok').click
+          expect(page).not_to have_selector 'input[name="tracking"]'
+        end
+        expect(page).to have_content tracking_number
+      end
+    end
+
+    context 'Changing carrier/shipping costs' do
+      before do
+        visit spree.edit_admin_order_path(order)
+      end
+
+      it 'allows admin to edit shipping costs' do
+        expect(page).not_to have_content 'UPS Ground $100.00'
+        within '.show-method' do
+          find('.fa-edit').click
+        end
+        within '.edit-method' do
+          find('.fa-ok').click
+        end
+        expect(page).to have_content 'UPS Ground $100.00'
+      end
+    end
+  else
+    context 'Adding tracking number' do
+      let(:tracking_number) { 'AA123' }
+
+      before { visit spree.edit_admin_order_path(order) }
+
+      it 'allows admin to edit tracking' do
+        within '.edit-tracking' do
+          expect(page).not_to have_content tracking_number
+          find('.js-edit').click
+          expect(page).to have_selector 'input[name="tracking"]'
+          fill_in :tracking, with: tracking_number
+          find('.js-save').click
+          expect(page).not_to have_selector 'input[name="tracking"]'
+          expect(page).to have_content tracking_number
+        end
+      end
+    end
+
+    context 'Changing carrier/shipping costs' do
+      let(:carrier_name) { 'Fedex' }
+      let(:select_name) { 'selected_shipping_method_id' }
+
+      before do
+        create :shipping_method, name: carrier_name
+        visit spree.edit_admin_order_path(order)
+      end
+
+      it 'allows admin to edit shipping costs' do
+        within '.edit-shipping-method' do
+          expect(page).not_to have_content carrier_name
+          find('.js-edit').click
+          expect(page).to have_selector "select[name='#{select_name}']"
+          select "#{carrier_name} $10.00", from: select_name
+          find('.js-save').click
+          expect(page).not_to have_selector "select[name='#{select_name}']"
+          expect(page).to have_content carrier_name
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Shipping costs and tracking areas in the admin order page were no more
synchronized with current Solidus behavior.
    
The code that is being removed in this commit, after some changes, was removed
from Solidus with commit 5497ee.

A few regression tests are added.

Together with functionality, also the layout was broken, see attached screenshot

<img width="882" alt="schermata 2019-01-17 alle 20 34 27" src="https://user-images.githubusercontent.com/141220/51343761-6649b080-1a97-11e9-8cbc-c8313b2bf1ec.png">
