### PR TITLE
Remove stale edit button

### DIFF
--- a/app/views/spree/admin/orders/_stock_item.html.erb
+++ b/app/views/spree/admin/orders/_stock_item.html.erb
@@ -36,7 +36,6 @@
         <% if can? :update, item %>
           <%= button_tag '', :class => 'save-item fa fa-ok no-text with-tip', :data => {'shipment-number' => shipment.number, 'variant-id' => item.variant.id, :action => 'save'}, :title => I18n.t('spree.actions.save'), :style => 'display: none' %>
           <%= link_to '', :class => 'cancel-item fa fa-cancel no-text with-tip', :data => {:action => 'cancel'}, :title => I18n.t('spree.actions.cancel'), :style => 'display: none' %>
-          <%= button_tag '', :class => 'edit-item fa fa-edit no-text with-tip', :data => {:action => 'edit'}, :title => I18n.t('spree.actions.edit') %>
           <%= button_tag '', :class => 'split-item fa fa-arrows-h no-text with-tip', :data => {:action => 'split', 'variant-id' => item.variant.id}, :title => I18n.t('spree.actions.split') %>
           <%= button_tag '', :class => 'delete-item fa fa-trash no-text with-tip', :data => {'shipment-number' => shipment.number, 'variant-id' => item.variant.id, :action => 'remove'}, :title => I18n.t('spree.actions.delete') %>
         <% end %>


### PR DESCRIPTION
REF #23 

The `edit` button is not working anymore. After some investigation it comes
out that the button was removed from Solidus back in 2014 with commit
`b252e9adcd02b5b0f0f89cdcfae583e72ae12fb7`.

Allo other issues with #23 have been fixed with recent commits. 