### PR TITLE
Lock SQLite3 to version 1.3

### DIFF
--- a/solidus_product_assembly.gemspec
+++ b/solidus_product_assembly.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'solidus_backend', [">= 1.0", "< 3"]
 
   s.add_development_dependency 'rspec-rails', '~> 3.4'
-  s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'sqlite3', '~> 1.3.6'
   s.add_development_dependency 'ffaker'
   s.add_development_dependency 'capybara', '~> 2.7'
   s.add_development_dependency 'database_cleaner', '~> 1.3'


### PR DESCRIPTION
SQLite3 v1.4 was released on February 4th, which breaks compatibility with ActiveRecord's adapter for said DB engine.