### PR TITLE
Remove assembly part prices from carton manifest

### DIFF
--- a/app/overrides/spree/admin/orders/_carton_manifest/_assembly_parts_price.html.erb.deface
+++ b/app/overrides/spree/admin/orders/_carton_manifest/_assembly_parts_price.html.erb.deface
@@ -1,0 +1,9 @@
+<!-- replace ".item-price" -->
+
+<% if item.variant.part? %>
+  <td class="item-price">---</td>
+<% else %>
+  <td class="item-price">
+    <%= line_item_shipment_price(item.line_item, item.quantity) %>
+  </td>
+<% end %>

--- a/app/overrides/spree/admin/orders/_carton_manifest/_assembly_parts_total_price.html.erb.deface
+++ b/app/overrides/spree/admin/orders/_carton_manifest/_assembly_parts_total_price.html.erb.deface
@@ -1,0 +1,9 @@
+<!-- replace ".item-total" -->
+
+<% if item.variant.part? %>
+  <td class="item-total align-center">---</td>
+<% else %>
+  <td class="item-total align-center">
+    <%= line_item_shipment_price(item.line_item, item.quantity) %>
+  </td>
+<% end %>


### PR DESCRIPTION
When listing assembly parts, it does not make sense to show the assembly price
(total price) for each part. A few dashes `---` will be shown instead, as already
happens in other parts of the admin when assemblies are involved.

Also, in order to avoid regressions a new feature spec that tests much of the 
admin order processing with product assemblies is added.