### PR TITLE
Round up default refund amount for assembly parts

### DIFF
--- a/app/models/spree/calculator/returns/assemblies_default_refund_amount.rb
+++ b/app/models/spree/calculator/returns/assemblies_default_refund_amount.rb
@@ -4,7 +4,13 @@ module Spree
   module Calculator::Returns
     class AssembliesDefaultRefundAmount < DefaultRefundAmount
       def compute(return_item)
-        super * return_item.inventory_unit.percentage_of_line_item
+        percentage = return_item.inventory_unit.percentage_of_line_item
+
+        if percentage < 1
+          (super * percentage).round 4, :up
+        else
+          super
+        end
       end
     end
   end

--- a/spec/features/admin/return_items_spec.rb
+++ b/spec/features/admin/return_items_spec.rb
@@ -11,19 +11,47 @@ describe "Return Items", type: :feature, js: true do
     let(:parts) { (1..3).map { create(:variant) } }
 
     before do
+      create :refund_reason, name: Spree::RefundReason::RETURN_PROCESSING_REASON, mutable: false
       bundle.parts << [parts]
-      order.reload.create_proposed_shipments
-      order.finalize!
-      order.update state: :complete
-      order.shipments.update_all state: :shipped
+      parts.each { |p| p.stock_items.first.set_count_on_hand 4 }
+      3.times { order.next }
+      create :payment, order: order, amount: order.amount
+      order.next
+      order.complete
+      order.payments.each(&:capture!)
+      order.shipments.each { |s| s.update state: :ready }
+      order.shipments.each(&:ship!)
     end
 
-    it 'builds one return item for each part, splitting the bundle price on them' do
+    it 'successfully generates a RMA, a reimbursement and a refund' do
       visit spree.edit_admin_order_path(order)
       expect(page).to have_selector '.line-item-total', text: '$10.00'
       click_link 'RMA'
       click_link 'New RMA'
-      expect(page).to have_selector '.return-item-pre-tax-refund-amount', text: '$3.33', count: 3
+
+      expect(page).to have_selector '.return-item-charged', text: '$3.33', count: 3
+      find('#select-all').click
+      select Spree::StockLocation.first.name, from: 'Stock Location'
+
+      click_button 'Create'
+
+      expect(page).to have_content 'Return Authorization has been successfully created!'
+      click_link 'Customer Returns'
+      click_link 'New Customer Return'
+      find('#select-all').click
+      page.execute_script %{$('option[value="receive"]').attr('selected', 'selected')}
+      select Spree::StockLocation.first.name, from: 'Stock Location'
+
+      click_button 'Create'
+
+      expect(page).to have_content 'Customer Return has been successfully created!'
+      click_button 'Create reimbursement'
+
+      click_button 'Reimburse'
+
+      within 'table.reimbursement-refunds' do
+        expect(page).to have_content '$10.00'
+      end
     end
   end
 


### PR DESCRIPTION
Solidus rounds down refund amounts, so in order to ensure the whole order is properly refunded when all assembly parts are returned some minimal rounding up is required, or there will very likely be one cent difference between the payment amount and the refund amount:

<img width="984" alt="Schermata 2019-04-17 alle 11 54 07" src="https://user-images.githubusercontent.com/141220/56281237-6c8a1000-610c-11e9-8e47-281bfda5df27.png">


See Solidus core method `Spree::Reimbursement#calculated_total` comments:

```ruby
  def calculated_total
    # rounding down to handle edge cases for consecutive partial returns where rounding
    # might cause us to try to reimburse more than was originally billed
    return_items.to_a.sum(&:total).to_d.round(2, :down)
  end
```

The existing integration spec was expanded in order to verify the whole refund process, starting from the RMA, then generating a return and finally the complete refund.