### PR TITLE
Fix return item amounts with multiple items

### DIFF
--- a/app/models/spree/calculator/returns/assemblies_default_refund_amount.rb
+++ b/app/models/spree/calculator/returns/assemblies_default_refund_amount.rb
@@ -5,12 +5,17 @@ module Spree
     class AssembliesDefaultRefundAmount < DefaultRefundAmount
       def compute(return_item)
         percentage = return_item.inventory_unit.percentage_of_line_item
-
-        if percentage < 1
-          (super * percentage).round 4, :up
+        if percentage < 1 && return_item.variant.part?
+          (super * percentage * variants_count(return_item)).round 4, :up
         else
           super
         end
+      end
+
+      def variants_count(return_item)
+        inventory_unit = return_item.inventory_unit
+        line_item = inventory_unit.line_item
+        line_item.inventory_units.where(variant_id: inventory_unit.variant_id).count
       end
     end
   end


### PR DESCRIPTION
Ref #46

When returning an order with assembly product line items with quantity > 1,
the suggested return amount calculator should consider also the quantity.

This is already done for regular products within Solidus codebase, so the
algorythm in `AssembliesDefaultRefundAmount#compute` must only consider
assembly product return items.