### PR TITLE
Fix build on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 cache: bundler
 language: ruby
 rvm:
-  - 2.3.1
+  - 2.4.3
 addons:
   chrome: stable
 before_script:

--- a/solidus_product_assembly.gemspec
+++ b/solidus_product_assembly.gemspec
@@ -27,7 +27,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec-rails', '~> 3.4'
   s.add_development_dependency 'sqlite3', '~> 1.3.6'
   s.add_development_dependency 'ffaker'
-  s.add_development_dependency 'capybara', '~> 2.7'
+  s.add_development_dependency 'capybara', '~> 3.19'
+  s.add_development_dependency 'puma', '~> 3.12'
   s.add_development_dependency 'database_cleaner', '~> 1.3'
   s.add_development_dependency 'simplecov'
 end


### PR DESCRIPTION
The current version of Chrome is not compatible anymore with Capybara 2.X, so
the gem version must be upgraded. In order to use the most recent version,
Ruby version must be upgraded too. The new Ruby version is the same of Solidus.