### PR TITLE
Show correct RMA amounts when assembly has more than one piece for var…

### DIFF
--- a/app/models/spree/calculator/returns/assemblies_default_refund_amount.rb
+++ b/app/models/spree/calculator/returns/assemblies_default_refund_amount.rb
@@ -6,16 +6,11 @@ module Spree
       def compute(return_item)
         percentage = return_item.inventory_unit.percentage_of_line_item
         if percentage < 1 && return_item.variant.part?
-          (super * percentage * variants_count(return_item)).round 4, :up
+          line_item = return_item.inventory_unit.line_item
+          (super * percentage * line_item.quantity).round 4, :up
         else
           super
         end
-      end
-
-      def variants_count(return_item)
-        inventory_unit = return_item.inventory_unit
-        line_item = inventory_unit.line_item
-        line_item.inventory_units.where(variant_id: inventory_unit.variant_id).count
       end
     end
   end

--- a/spec/features/admin/return_items_spec.rb
+++ b/spec/features/admin/return_items_spec.rb
@@ -12,6 +12,7 @@ describe "Return Items", type: :feature, js: true do
     before do
       create :refund_reason, name: Spree::RefundReason::RETURN_PROCESSING_REASON, mutable: false
       bundle.parts << [parts]
+      bundle.set_part_count(parts.first, 2)
       parts.each { |p| p.stock_items.first.set_count_on_hand 4 }
       3.times { order.next }
       create :payment, order: order, amount: order.amount
@@ -33,7 +34,7 @@ describe "Return Items", type: :feature, js: true do
         click_link 'RMA'
         click_link 'New RMA'
 
-        expect(page).to have_selector '.return-item-charged', text: '$3.33', count: 3
+        expect(page).to have_selector '.return-item-charged', text: '$2.50', count: 4
 
         find('#select-all').click
         select Spree::StockLocation.first.name, from: 'Stock Location'
@@ -70,7 +71,7 @@ describe "Return Items", type: :feature, js: true do
         click_link 'RMA'
         click_link 'New RMA'
 
-        expect(page).to have_selector '.return-item-charged', text: '$3.33', count: 6
+        expect(page).to have_selector '.return-item-charged', text: '$2.50', count: 8
 
         find('#select-all').click
         select Spree::StockLocation.first.name, from: 'Stock Location'


### PR DESCRIPTION
…iant

The previous algorithm was producing wrong amounts in the edge case when the
product assembly is composed of more than one piece of a specific variant.

Closes issue https://github.com/solidusio-contrib/solidus_product_assembly/issues/46