### PR TITLE
Update `#determine_target_shipment` after Solidus #3197

### DIFF
--- a/app/models/spree/order_inventory_assembly.rb
+++ b/app/models/spree/order_inventory_assembly.rb
@@ -21,8 +21,14 @@ module Spree
           self.variant = part
 
           if existing_parts < total_parts
-            shipment ||= determine_target_shipment
-            add_to_shipment(shipment, total_parts - existing_parts)
+            if method(:determine_target_shipment).arity == 1
+              quantity = total_parts - existing_parts
+              shipment = determine_target_shipment(quantity) unless shipment
+              add_to_shipment(shipment, quantity)
+            else
+              shipment = determine_target_shipment unless shipment
+              add_to_shipment(shipment, total_parts - existing_parts)
+            end
           elsif existing_parts > total_parts
             quantity = existing_parts - total_parts
             if shipment.present?


### PR DESCRIPTION
This PR becomes necessary after https://github.com/solidusio/solidus/pull/3197 is merged in Solidus master. 

ATM the Solidus version in this branch points to the version included in https://github.com/solidusio/solidus/pull/3197 in order to ensure functionality.

The arity of the method `OrderInventory#determine_target_shipment` changes with
Solidus PR #3197, this change must be ported to `OrderInventoryAssembly#verify`