### PR TITLE
Use `ActionView::Helpers::TranslationHelper.t`

### DIFF
--- a/app/views/spree/admin/orders/_assemblies.html.erb
+++ b/app/views/spree/admin/orders/_assemblies.html.erb
@@ -1,7 +1,7 @@
 <% if order.line_items.assemblies.any? %>
   <fieldset class="no-border-bottom">
     <legend align="center" class="" data-hook="">
-      <%= I18n.t('spree.product_bundles') %>
+      <%= t('spree.product_bundles') %>
     </legend>
   </fieldset>
 
@@ -43,10 +43,10 @@
           <td class="line-item-total align-center"><%= line_item_shipment_price(item, item.quantity) %></td>
           <td class="cart-line-item-delete actions" data-hook="cart_line_item_delete">
             <% if can? :update, item %>
-              <%= link_to '', '#', :class => 'save-line-item fa fa-ok no-text with-tip',       :title => I18n.t('spree.actions.save') %>
-              <%= link_to '', '#', :class => 'cancel-line-item fa fa-cancel no-text with-tip', :title => I18n.t('spree.actions.cancel') %>
-              <%= link_to '', '#', :class => 'edit-line-item fa fa-edit no-text with-tip',     :title => I18n.t('spree.actions.edit') %>
-              <%= link_to '', '#', :class => 'delete-line-item fa fa-trash no-text with-tip',  :title => I18n.t('spree.actions.delete') %>
+              <%= link_to '', '#', :class => 'save-line-item fa fa-ok no-text with-tip',       :title => t('spree.actions.save') %>
+              <%= link_to '', '#', :class => 'cancel-line-item fa fa-cancel no-text with-tip', :title => t('spree.actions.cancel') %>
+              <%= link_to '', '#', :class => 'edit-line-item fa fa-edit no-text with-tip',     :title => t('spree.actions.edit') %>
+              <%= link_to '', '#', :class => 'delete-line-item fa fa-trash no-text with-tip',  :title => t('spree.actions.delete') %>
             <% end %>
           </td>
         <% end %>

--- a/app/views/spree/admin/orders/_stock_contents_2_3.html.erb
+++ b/app/views/spree/admin/orders/_stock_contents_2_3.html.erb
@@ -4,7 +4,7 @@
   <tr class="edit-method hidden total">
     <td colspan="5">
       <div class="field alpha five columns">
-        <%= label_tag 'selected_shipping_rate_id', I18n.t('spree.shipping_method') %>
+        <%= label_tag 'selected_shipping_rate_id', t('spree.shipping_method') %>
         <%= select_tag :selected_shipping_rate_id,
               options_for_select(shipment.shipping_rates.map {|sr| ["#{sr.name} #{sr.display_price}", sr.id] }, shipment.selected_shipping_rate_id),
               {:class => 'select2 fullwidth', :data => {'shipment-number' => shipment.number } } %>
@@ -13,9 +13,9 @@
     <td class="actions">
       <% if can? :update, shipment %>
         <%= link_to '', '#', :class => 'save-method fa fa-ok no-text with-tip',
-          :data => {'shipment-number' => shipment.number, :action => 'save'}, title: I18n.t('spree.actions.save') %>
+          :data => {'shipment-number' => shipment.number, :action => 'save'}, title: t('spree.actions.save') %>
         <%= link_to '', '#', :class => 'cancel-method fa fa-cancel no-text with-tip',
-          :data => {:action => 'cancel'}, :title => I18n.t('spree.actions.cancel') %>
+          :data => {:action => 'cancel'}, :title => t('spree.actions.cancel') %>
       <% end %>
     </td>
   </tr>
@@ -30,25 +30,25 @@
       <span><%= shipment.display_cost %></span>
     </td>
   <% else %>
-    <td colspan='5'><%= I18n.t('spree.no_shipping_method_selected') %></td>
+    <td colspan='5'><%= t('spree.no_shipping_method_selected') %></td>
   <% end %>
 
   <td class="actions">
     <% if can? :update, shipment %>
-      <%= link_to '', '#', :class => 'edit-method fa fa-edit no-text with-tip', :data => {:action => 'edit'}, :title => I18n.t('spree.actions.edit') %>
+      <%= link_to '', '#', :class => 'edit-method fa fa-edit no-text with-tip', :data => {:action => 'edit'}, :title => t('spree.actions.edit') %>
     <% end %>
   </td>
 </tr>
 
 <tr class="edit-tracking hidden total">
   <td colspan="5">
-    <label><%= I18n.t('spree.tracking_number') %>:</label>
+    <label><%= t('spree.tracking_number') %>:</label>
     <%= text_field_tag :tracking, shipment.tracking %>
   </td>
   <td class="actions">
     <% if can? :update, shipment %>
-      <%= link_to '', '#', :class => 'save-tracking fa fa-ok no-text with-tip', :data => {'shipment-number' => shipment.number, :action => 'save'}, :title => I18n.t('spree.actions.save') %>
-      <%= link_to '', '#', :class => 'cancel-tracking fa fa-cancel no-text with-tip', :data => {:action => 'cancel'}, :title => I18n.t('spree.actions.cancel') %>
+      <%= link_to '', '#', :class => 'save-tracking fa fa-ok no-text with-tip', :data => {'shipment-number' => shipment.number, :action => 'save'}, :title => t('spree.actions.save') %>
+      <%= link_to '', '#', :class => 'cancel-tracking fa fa-cancel no-text with-tip', :data => {:action => 'cancel'}, :title => t('spree.actions.cancel') %>
     <% end %>
   </td>
 </tr>
@@ -58,12 +58,12 @@
     <% if shipment.tracking.present? %>
       <%= shipment.tracking %>
     <% else %>
-      <%= I18n.t('spree.no_tracking_present') %>
+      <%= t('spree.no_tracking_present') %>
     <% end %>
   </td>
   <td class="actions">
     <% if can? :update, shipment %>
-      <%= link_to '', '#', :class => 'edit-tracking fa fa-edit no-text with-tip', :data => {:action => 'edit'}, :title => I18n.t('spree.actions.edit') %>
+      <%= link_to '', '#', :class => 'edit-tracking fa fa-edit no-text with-tip', :data => {:action => 'edit'}, :title => t('spree.actions.edit') %>
     <% end %>
   </td>
 </tr>

--- a/app/views/spree/admin/orders/_stock_contents_2_4.html.erb
+++ b/app/views/spree/admin/orders/_stock_contents_2_4.html.erb
@@ -4,7 +4,7 @@
   <tr class="edit-method hidden total">
     <td colspan="5">
       <div class="field alpha five columns">
-        <%= label_tag 'selected_shipping_rate_id', I18n.t('spree.shipping_method') %>
+        <%= label_tag 'selected_shipping_rate_id', t('spree.shipping_method') %>
         <%= select_tag :selected_shipping_rate_id,
               options_for_select(shipment.shipping_rates.map {|sr| ["#{sr.name} #{sr.display_price}", sr.id] }, shipment.selected_shipping_rate_id),
               {:class => 'select2 fullwidth', :data => {'shipment-number' => shipment.number } } %>
@@ -13,9 +13,9 @@
     <td class="actions">
       <% if can? :update, shipment %>
         <%= button_tag '', :class => 'save-method fa fa-ok no-text with-tip',
-          :data => {'shipment-number' => shipment.number, :action => 'save'}, title: I18n.t('spree.actions.save') %>
+          :data => {'shipment-number' => shipment.number, :action => 'save'}, title: t('spree.actions.save') %>
         <%= button_tag '', :class => 'cancel-method fa fa-cancel no-text with-tip',
-          :data => {:action => 'cancel'}, :title => I18n.t('spree.actions.cancel') %>
+          :data => {:action => 'cancel'}, :title => t('spree.actions.cancel') %>
       <% end %>
     </td>
   </tr>
@@ -30,25 +30,25 @@
       <span><%= shipment.display_cost %></span>
     </td>
   <% else %>
-    <td colspan='5'><%= I18n.t('spree.no_shipping_method_selected') %></td>
+    <td colspan='5'><%= t('spree.no_shipping_method_selected') %></td>
   <% end %>
 
   <td class="actions">
     <% if can? :update, shipment %>
-      <%= button_tag '', :class => 'edit-method fa fa-edit no-text with-tip', :data => {:action => 'edit'}, :title => I18n.t('spree.actions.edit') %>
+      <%= button_tag '', :class => 'edit-method fa fa-edit no-text with-tip', :data => {:action => 'edit'}, :title => t('spree.actions.edit') %>
     <% end %>
   </td>
 </tr>
 
 <tr class="edit-tracking hidden total">
   <td colspan="5">
-    <label><%= I18n.t('spree.tracking_number') %>:</label>
+    <label><%= t('spree.tracking_number') %>:</label>
     <%= text_field_tag :tracking, shipment.tracking %>
   </td>
   <td class="actions">
     <% if can? :update, shipment %>
-      <%= button_tag '', :class => 'save-tracking fa fa-ok no-text with-tip', :data => {'shipment-number' => shipment.number, :action => 'save'}, :title => I18n.t('spree.actions.save') %>
-      <%= button_tag '', :class => 'cancel-tracking fa fa-cancel no-text with-tip', :data => {:action => 'cancel'}, :title => I18n.t('spree.actions.cancel') %>
+      <%= button_tag '', :class => 'save-tracking fa fa-ok no-text with-tip', :data => {'shipment-number' => shipment.number, :action => 'save'}, :title => t('spree.actions.save') %>
+      <%= button_tag '', :class => 'cancel-tracking fa fa-cancel no-text with-tip', :data => {:action => 'cancel'}, :title => t('spree.actions.cancel') %>
     <% end %>
   </td>
 </tr>

--- a/app/views/spree/admin/orders/_stock_item.html.erb
+++ b/app/views/spree/admin/orders/_stock_item.html.erb
@@ -4,7 +4,7 @@
     <td class="item-name">
       <%= link_to item.variant.product.name, edit_admin_product_path(item.variant.product) %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>
       <% if item.part && item.line_item %>
-        <i><%= I18n.t('spree.part_of_bundle', sku: item.product.sku) %></i>
+        <i><%= t('spree.part_of_bundle', sku: item.product.sku) %></i>
       <% elsif item.variant.sku.present? %>
         <strong><%= Spree::Variant.human_attribute_name(:sku) %>:</strong> <%= item.variant.sku %>
       <% end %>
@@ -36,10 +36,10 @@
     <td class="cart-item-delete actions" data-hook="cart_item_delete">
       <% if !shipment.shipped? %>
         <% if can? :update, item %>
-          <%= button_tag '', :class => 'save-item fa fa-ok no-text with-tip', :data => {'shipment-number' => shipment.number, 'variant-id' => item.variant.id, :action => 'save'}, :title => I18n.t('spree.actions.save'), :style => 'display: none' %>
-          <%= link_to '', :class => 'cancel-item fa fa-cancel no-text with-tip', :data => {:action => 'cancel'}, :title => I18n.t('spree.actions.cancel'), :style => 'display: none' %>
-          <%= button_tag '', :class => 'split-item fa fa-arrows-h no-text with-tip', :data => {:action => 'split', 'variant-id' => item.variant.id}, :title => I18n.t('spree.actions.split') %>
-          <%= button_tag '', :class => 'delete-item fa fa-trash no-text with-tip', :data => {'shipment-number' => shipment.number, 'variant-id' => item.variant.id, :action => 'remove'}, :title => I18n.t('spree.actions.delete') %>
+          <%= button_tag '', :class => 'save-item fa fa-ok no-text with-tip', :data => {'shipment-number' => shipment.number, 'variant-id' => item.variant.id, :action => 'save'}, :title => t('spree.actions.save'), :style => 'display: none' %>
+          <%= link_to '', :class => 'cancel-item fa fa-cancel no-text with-tip', :data => {:action => 'cancel'}, :title => t('spree.actions.cancel'), :style => 'display: none' %>
+          <%= button_tag '', :class => 'split-item fa fa-arrows-h no-text with-tip', :data => {:action => 'split', 'variant-id' => item.variant.id}, :title => t('spree.actions.split') %>
+          <%= button_tag '', :class => 'delete-item fa fa-trash no-text with-tip', :data => {'shipment-number' => shipment.number, 'variant-id' => item.variant.id, :action => 'remove'}, :title => t('spree.actions.delete') %>
         <% end %>
       <% end %>
     </td>

--- a/app/views/spree/admin/parts/_parts_table.html.erb
+++ b/app/views/spree/admin/parts/_parts_table.html.erb
@@ -1,10 +1,10 @@
 <table class="index">
   <thead>
   	<tr>
-  	  <th><%= I18n.t('spree.sku') %></th>
-  		<th><%= I18n.t('spree.name') %></th>
-  		<th><%= I18n.t('spree.options') %></th>
-  		<th><%= I18n.t('spree.qty') %></th>
+  	  <th><%= t('spree.sku') %></th>
+  		<th><%= t('spree.name') %></th>
+  		<th><%= t('spree.options') %></th>
+  		<th><%= t('spree.qty') %></th>
   	</tr>
   </thead>
   <tbody>
@@ -17,20 +17,20 @@
   	    <td class="actions">
           <%= link_to_with_icon(
             'edit',
-            I18n.t('spree.actions.edit'),
+            t('spree.actions.edit'),
             set_count_admin_product_part_url(@product, part),
             :class => "set_count_admin_product_part_link save-line-item") %>
 
           <%= link_to_with_icon(
             'delete',
-            I18n.t('spree.actions.delete'),
+            t('spree.actions.delete'),
             remove_admin_product_part_url(@product, part),
             class: "remove_admin_product_part_link delete-line-item") %>
   	    </td>
       </tr>
     <% end %>
     <% if parts.empty? %>
-     <tr><td colspan="5"><%= I18n.t('spree.none') %>.</td></tr>
+     <tr><td colspan="5"><%= t('spree.none') %>.</td></tr>
     <% end %>
   </tbody>
 </table>

--- a/app/views/spree/admin/parts/available.html.erb
+++ b/app/views/spree/admin/parts/available.html.erb
@@ -6,13 +6,13 @@
   }
 </script>
 
-<h4><%= I18n.t('spree.available_parts') %></h4>
+<h4><%= t('spree.available_parts') %></h4>
 <table class="index">
 	<thead>
 		<tr>
-  		<th><%= I18n.t('spree.name') %></th>
-  		<th><%= I18n.t('spree.options') %></th>
-  		<th><%= I18n.t('spree.qty') %></th>
+  		<th><%= t('spree.name') %></th>
+  		<th><%= t('spree.options') %></th>
+  		<th><%= t('spree.qty') %></th>
   		<th></th>
 		</tr>
 	</thead>
@@ -27,19 +27,19 @@
                 options_for_select(product.variants.map { |v| [variant_options(v), v.id] }) %>
           <% else %>
             <%= hidden_field_tag "part[id]", product.master.id %>
-            <%= I18n.t(:no_variants) %>
+            <%= t(:no_variants) %>
           <% end %>
         </td>
         <td><%= text_field_tag "part[count]", 1 %></td>
 		    <td class="actions">
-		      <%= link_to(I18n.t('spree.select'),
+		      <%= link_to(t('spree.select'),
 		                  admin_product_parts_path(@product),
 		                  :class => "add_product_part_link btn btn-primary") %>
 		    </td>
       </tr>
     <% end %>
     <% if @available_products.empty? %>
-     <tr><td colspan="3"><%= I18n.t('spree.no_match_found') %>.</td></tr>
+     <tr><td colspan="3"><%= t('spree.no_match_found') %>.</td></tr>
     <% end %>
   </tbody>
 </table>

--- a/app/views/spree/admin/parts/available.js.erb
+++ b/app/views/spree/admin/parts/available.js.erb
@@ -5,13 +5,13 @@
     else row.style.display = '';
   }
 </script>
-<h4><%= I18n.t('spree.available_parts') %></h4>
+<h4><%= t('spree.available_parts') %></h4>
 <table class="index">
 	<thead>
 		<tr>
-  		<th><%= I18n.t('spree.name') %></th>
-  		<th><%= I18n.t('spree.options') %></th>
-  		<th><%= I18n.t('spree.qty') %></th>
+  		<th><%= t('spree.name') %></th>
+  		<th><%= t('spree.options') %></th>
+  		<th><%= t('spree.qty') %></th>
   		<th></th>
 		</tr>
 	</thead>
@@ -26,19 +26,19 @@
                 options_for_select(product.variants.map { |v| [variant_options(v), v.id] }) %>
           <% else %>
             <%= hidden_field_tag "part[id]", product.master.id %>
-            <%= I18n.t('spree.no_variants') %>
+            <%= t('spree.no_variants') %>
           <% end %>
         </td>
         <td><%= text_field_tag "part[count]", 1 %></td>
 		    <td class="actions">
-		      <%= link_to(icon('add') + ' ' + I18n.t('spree.select'),
+		      <%= link_to(icon('add') + ' ' + t('spree.select'),
 		                  admin_product_parts_path(@product),
 		                  :class => "add_product_part_link") %>
 		    </td>
       </tr>
     <% end %>
     <% if @available_products.empty? %>
-     <tr><td colspan="3"><%= I18n.t('spree.no_match_found') %>.</td></tr>
+     <tr><td colspan="3"><%= t('spree.no_match_found') %>.</td></tr>
     <% end %>
   </tbody>
 </table>

--- a/app/views/spree/admin/parts/index.html.erb
+++ b/app/views/spree/admin/parts/index.html.erb
@@ -7,7 +7,7 @@
 </div>
 
 <%= form_tag('#') do %>
-  <label><%= I18n.t('spree.search') %>:</label>
+  <label><%= t('spree.search') %>:</label>
   <input id="searchtext" size="25">
   <button id="search_parts_button" class="fa fa-search button" name="button">Search</button>
 <% end %>

--- a/app/views/spree/admin/products/_product_assembly_fields.html.erb
+++ b/app/views/spree/admin/products/_product_assembly_fields.html.erb
@@ -1,12 +1,12 @@
 <div class="left six columns alpha">
   <div class="field">
-    <%= f.label :can_be_part, I18n.t('spree.can_be_part')%>
+    <%= f.label :can_be_part, t('spree.can_be_part')%>
     <%= f.check_box(:can_be_part) %>
   </div>
 </div>
 <div class="right six columns omega">
   <div class="field">
-    <%= f.label :individual_sale, I18n.t('spree.individual_sale')%>
+    <%= f.label :individual_sale, t('spree.individual_sale')%>
     <%= f.check_box(:individual_sale) %>
   </div>
 </div>

--- a/app/views/spree/admin/shared/_product_assembly_product_tabs.html.erb
+++ b/app/views/spree/admin/shared/_product_assembly_product_tabs.html.erb
@@ -1,3 +1,3 @@
 <li<%= ' class="active"' if current == "Parts" %>>
-  <%= link_to_with_icon 'sitemap', I18n.t('spree.parts'), admin_product_parts_url(@product) %>
+  <%= link_to_with_icon 'sitemap', t('spree.parts'), admin_product_parts_url(@product) %>
 </li>


### PR DESCRIPTION
Vanilla `I18n.t` should not be used in views; the wrapped version from `ActionView::Helpers::TranslationHelper.t` should be unsed instead.

See https://api.rubyonrails.org/v5.2.2/classes/ActionView/Helpers/TranslationHelper.html