### PR TITLE
Remove deprecation for Reimbursement#simulate

### DIFF
--- a/spec/features/admin/return_items_spec.rb
+++ b/spec/features/admin/return_items_spec.rb
@@ -5,6 +5,10 @@ describe "Return Items", type: :feature, js: true do
 
   let(:line_item) { order.line_items.first }
 
+  before do
+    allow_any_instance_of(Spree::Admin::ReimbursementsController).to receive(:try_spree_current_user) { Spree.user_class.new }
+  end
+
   context 'when the order product is a bundle' do
     let(:bundle) { line_item.product }
     let(:parts) { (1..3).map { create(:variant) } }


### PR DESCRIPTION
In the current version of Solidus it is required to pass an user to this method.