### PR TITLE
Zeitwerk compatibility fix

### DIFF
--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -1,6 +1,6 @@
-module Spree
+module Spree::CheckoutControllerDecorator
   if defined? Spree::Frontend
-    CheckoutController.class_eval do
+    Spree::CheckoutController.class_eval do
       # Override because we don't want to remove unshippable items from the order
       # A bundle itself is an unshippable item
       def before_payment; end


### PR DESCRIPTION
I was able to use this extension with rails-6.0.0 and solidus (2.10.0.beta1) after making these changes.