### PR TITLE
Show item price unless its a bundle product

### DIFF
--- a/app/overrides/spree/admin/orders/_carton_manifest/_assembly_parts_price.html.erb.deface
+++ b/app/overrides/spree/admin/orders/_carton_manifest/_assembly_parts_price.html.erb.deface
@@ -1,6 +1,6 @@
 <!-- replace ".item-price" -->
 
-<% if item.variant.part? %>
+<% if item.line_item.product.assembly? %>
   <td class="item-price">---</td>
 <% else %>
   <td class="item-price">

--- a/app/overrides/spree/admin/orders/_carton_manifest/_assembly_parts_total_price.html.erb.deface
+++ b/app/overrides/spree/admin/orders/_carton_manifest/_assembly_parts_total_price.html.erb.deface
@@ -1,6 +1,6 @@
 <!-- replace ".item-total" -->
 
-<% if item.variant.part? %>
+<% if item.line_item.product.assembly? %>
   <td class="item-total align-center">---</td>
 <% else %>
   <td class="item-total align-center">


### PR DESCRIPTION
The goal of this PR is to show items price when displaying carton in admin, unless the product being sold is an assembly one.
This change is because in some projects a product/variant could be both a part of an assembly product and can be sold individually too.