### PR TITLE
Fix deprecation warning about SolidusSupport.solidus_gem_version

### DIFF
--- a/app/decorators/models/solidus_product_assembly/spree/stock/inventory_unit_builder_decorator.rb
+++ b/app/decorators/models/solidus_product_assembly/spree/stock/inventory_unit_builder_decorator.rb
@@ -18,7 +18,7 @@ module SolidusProductAssembly
             variant: variant,
             line_item: line_item,
           }
-          if SolidusSupport.solidus_gem_version < Gem::Version.new('2.5.x')
+          if ::Spree.solidus_gem_version < Gem::Version.new('2.5.x')
             inventory_unit_attributes[:order] = @order
           end
           @order.inventory_units.includes(


### PR DESCRIPTION
I've got a lot of these warnings in my logs : 

```
DEPRECATION WARNING: SolidusSupport.solidus_gem_version is deprecated and will be removed in solidus_support 1.0. Please use Spree.solidus_gem_version instead. (called from build_inventory_unit at /home/circleci/epicery/api/vendor/bundle/bundler/gems/solidus_product_assembly-c52438ea289e/app/models/spree/stock/inventory_unit_builder_decorator.rb:18)
```

This change should get rid of them :)