### PR TITLE
Fix #determine_target_shipment call

### DIFF
--- a/app/models/spree/order_inventory_assembly.rb
+++ b/app/models/spree/order_inventory_assembly.rb
@@ -21,8 +21,9 @@ module Spree
           self.variant = part
 
           if existing_parts < total_parts
-            shipment ||= determine_target_shipment
-            add_to_shipment(shipment, total_parts - existing_parts)
+            quantity = total_parts - existing_parts
+            shipment ||= determine_target_shipment(quantity)
+            add_to_shipment(shipment, quantity)
           elsif existing_parts > total_parts
             quantity = existing_parts - total_parts
             if shipment.present?


### PR DESCRIPTION
solidusio/solidus#3197 add a mandatory parameter which we should send

As I understand the rest of the code, we should send the missing quantity, not
the total quantity but I'm not completely sure about that.