### PR TITLE
Sortable table for Product > Parts

### DIFF
--- a/app/controllers/spree/admin/parts_controller.rb
+++ b/app/controllers/spree/admin/parts_controller.rb
@@ -39,6 +39,18 @@ class Spree::Admin::PartsController < Spree::Admin::BaseController
     render 'spree/admin/parts/update_parts_table'
   end
 
+  def update_positions
+    ActiveRecord::Base.transaction do
+      params[:positions].each do |variant_id, index|
+        @product.assemblies_parts.find_by(part_id: variant_id).set_list_position(index)
+      end
+    end
+
+    respond_to do |format|
+      format.js { head :no_content }
+    end
+  end
+
   private
 
   def find_product

--- a/app/decorators/models/solidus_product_assembly/spree/product_decorator.rb
+++ b/app/decorators/models/solidus_product_assembly/spree/product_decorator.rb
@@ -5,11 +5,13 @@ module SolidusProductAssembly
     module ProductDecorator
       def self.prepended(base)
         base.class_eval do
-          has_and_belongs_to_many :parts, class_name: "Spree::Variant",
+          has_and_belongs_to_many :parts, -> { order('spree_assemblies_parts.position ASC') },
+                                          class_name: "Spree::Variant",
                                           join_table: "spree_assemblies_parts",
                                           foreign_key: "assembly_id", association_foreign_key: "part_id"
 
-          has_many :assemblies_parts, class_name: "Spree::AssembliesPart",
+          has_many :assemblies_parts, -> { order(position: :asc) },
+                                      class_name: "Spree::AssembliesPart",
                                       foreign_key: "assembly_id"
 
           scope :individual_saled, -> { where(individual_sale: true) }

--- a/app/models/spree/assemblies_part.rb
+++ b/app/models/spree/assemblies_part.rb
@@ -2,6 +2,8 @@
 
 module Spree
   class AssembliesPart < ApplicationRecord
+    acts_as_list scope: :assembly
+
     belongs_to :assembly, class_name: "Spree::Product",
                           foreign_key: "assembly_id", touch: true
 

--- a/app/views/spree/admin/parts/_parts_table.html.erb
+++ b/app/views/spree/admin/parts/_parts_table.html.erb
@@ -45,6 +45,6 @@
 <%= javascript_tag do %>
 $(document).ready(function() {
   subscribe_product_part_links();
-  Spree.refresh_sortable_tables();
+  Spree.SortableTable.refresh();
 });
 <% end if request.xhr? %>

--- a/app/views/spree/admin/parts/_parts_table.html.erb
+++ b/app/views/spree/admin/parts/_parts_table.html.erb
@@ -1,19 +1,26 @@
-<table class="index">
+<table class="index sortable" data-sortable-link="<%= update_positions_admin_product_parts_path(@product) %>">
   <thead>
   	<tr>
+      <th><!--- handle line to sort --></th>
   	  <th><%= t('spree.sku') %></th>
   		<th><%= t('spree.name') %></th>
   		<th><%= t('spree.options') %></th>
   		<th><%= t('spree.qty') %></th>
+      <th><!--- actions --></th>
   	</tr>
   </thead>
   <tbody>
-    <% parts.each do |part| %>
+    <% parts.each_with_index do |part, index| %>
       <tr id="<%= dom_id(part, :sel)%>">
+        <td>
+          <% if can? :update_positions, Spree::AssembliesPart %>
+            <span class="handle"></span>
+          <% end %>
+        </td>
         <td><%= part.sku %></td>
         <td><%= part.product.name %></td>
         <td><%= variant_options part %></td>
-        <td><%= text_field_tag :count, @product.count_of(part) %></td>
+        <td><%= text_field_tag :count, @product.count_of(part), id: "count-#{index+1}" %></td>
   	    <td class="actions">
           <%= link_to_with_icon(
             'edit',
@@ -34,4 +41,10 @@
     <% end %>
   </tbody>
 </table>
-<%= javascript_tag("subscribe_product_part_links();") if request.xhr? %>
+
+<%= javascript_tag do %>
+$(document).ready(function() {
+  subscribe_product_part_links();
+  Spree.refresh_sortable_tables();
+});
+<% end if request.xhr? %>

--- a/app/views/spree/admin/shared/_product_assembly_product_tabs.html.erb
+++ b/app/views/spree/admin/shared/_product_assembly_product_tabs.html.erb
@@ -1,3 +1,3 @@
-<li<%= ' class="active"' if current == "Parts" %>>
+<%= content_tag :li, class: ('active' if current == 'Parts') do %>
   <%= link_to_with_icon 'sitemap', t('spree.parts'), admin_product_parts_url(@product) %>
-</li>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Spree::Core::Engine.routes.draw do
         collection do
           post :available
           get  :selected
+          post :update_positions
         end
       end
     end

--- a/db/migrate/20200826181504_add_position_to_spree_assemblies_parts.rb
+++ b/db/migrate/20200826181504_add_position_to_spree_assemblies_parts.rb
@@ -1,0 +1,5 @@
+class AddPositionToSpreeAssembliesParts < ActiveRecord::Migration[4.2]
+  def change
+    add_column :spree_assemblies_parts, :position, :integer
+  end
+end

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -32,5 +32,37 @@ describe Spree::Product do
       @product.set_part_count(@part2.master, 2)
       expect(@product.count_of(@part2.master)).to eq 2
     end
+
+    it 'returns the parts in the correct order' do
+      ordered_ids = @product.parts.pluck(:id)
+
+      expect(ordered_ids.first).to eq(@part1.id)
+      expect(ordered_ids.second).to eq(@part2.id)
+    end
+
+    it 'returns the assemblies parts in the correct order' do
+      ordered_ids = @product.assemblies_parts.pluck(:part_id)
+
+      expect(ordered_ids.first).to eq(@part1.id)
+      expect(ordered_ids.second).to eq(@part2.id)
+    end
+
+    context 'when the user reverse the order' do
+      before { @product.assemblies_parts.first.set_list_position(2) }
+
+      it 'returns the parts in the new order' do
+        ordered_ids = @product.parts.pluck(:id)
+
+        expect(ordered_ids.first).to eq(@part2.id)
+        expect(ordered_ids.second).to eq(@part1.id)
+      end
+
+      it 'returns the assemblies parts in the new order' do
+        ordered_ids = @product.assemblies_parts.pluck(:part_id)
+
+        expect(ordered_ids.first).to eq(@part2.id)
+        expect(ordered_ids.second).to eq(@part1.id)
+      end
+    end
   end
 end


### PR DESCRIPTION
**WHY**

It is interesting for the Marketing to create campaigns showing the
most famous products on the top of the kit. So it makes sense to do
the same when the customer access the kit in the store.

**HOW**

- Added AssembliesPart#position
- Created a custom update_positions action for PartsController
  - The generic one was not prepared for this kind of relation
- Added default order by position on ProductDecorator
  - For parts and assemblies_parts relations (To be used in the store)
- Quick fixes
  - The browser was warning about too much elements with the same id
  - The tab Parts was not being set as active

**DEPENDENCY**

`Spree.SortableTable.refresh();` (https://github.com/solidusio/solidus/pull/3754)