### PR TITLE
Fix failing test in shipment_spec due to missing store

### DIFF
--- a/spec/models/spree/shipment_spec.rb
+++ b/spec/models/spree/shipment_spec.rb
@@ -5,6 +5,7 @@ require 'spec_helper'
 module Spree
   describe Shipment do
     context "order has one product assembly" do
+      let!(:store) { create(:store) }
       let(:order) { Order.create }
       let(:bundle) { create(:variant) }
       let!(:parts) { (1..2).map { create(:variant) } }


### PR DESCRIPTION
We need a store to satisfy the presence validation on `:store_id` as defined in solidus_core's `Spree::Order` model.