### PR TITLE
Display parts' available_on in the admin's "parts" tab (feature proposal)

### DIFF
--- a/app/views/spree/admin/parts/_parts_table.html.erb
+++ b/app/views/spree/admin/parts/_parts_table.html.erb
@@ -2,7 +2,8 @@
   <thead>
   	<tr>
   	  <th><%= t('spree.sku') %></th>
-  		<th><%= t('spree.name') %></th>
+      <th><%= t('spree.name') %></th>
+      <th><%= t('spree.available_on') %></th>
   		<th><%= t('spree.options') %></th>
   		<th><%= t('spree.qty') %></th>
   	</tr>
@@ -12,6 +13,7 @@
       <tr id="<%= dom_id(part, :sel)%>">
         <td><%= part.sku %></td>
         <td><%= part.product.name %></td>
+        <td><%= part.product.available_on %></td>
         <td><%= variant_options part %></td>
         <td><%= text_field_tag :count, @product.count_of(part) %></td>
   	    <td class="actions">

--- a/app/views/spree/admin/parts/available.html.erb
+++ b/app/views/spree/admin/parts/available.html.erb
@@ -10,7 +10,8 @@
 <table class="index">
 	<thead>
 		<tr>
-  		<th><%= t('spree.name') %></th>
+      <th><%= t('spree.name') %></th>
+      <th><%= t('spree.available_on') %></th>
   		<th><%= t('spree.options') %></th>
   		<th><%= t('spree.qty') %></th>
   		<th></th>
@@ -21,6 +22,7 @@
       <tr id="<%= dom_id(product) %>">
 
         <td><%= product.name %></td>
+        <td><%= product.available_on %></td>
         <td>
           <% if product.has_variants? %>
             <%= select_tag "part[id]",

--- a/app/views/spree/admin/parts/available.js.erb
+++ b/app/views/spree/admin/parts/available.js.erb
@@ -9,7 +9,8 @@
 <table class="index">
 	<thead>
 		<tr>
-  		<th><%= t('spree.name') %></th>
+        <th><%= t('spree.name') %></th>
+        <th><%= t('spree.available_on') %></th>
   		<th><%= t('spree.options') %></th>
   		<th><%= t('spree.qty') %></th>
   		<th></th>
@@ -20,6 +21,7 @@
       <tr id="<%= dom_id(product) %>">
 
         <td><%= product.name %></td>
+        <td><%= product.available_on %></td>
         <td>
           <% if product.has_variants? %>
             <%= select_tag "part[id]",


### PR DESCRIPTION
At @epicery, account managers (who handle product catalogs) felt the need to know whether products are available when creating a bundle of products.

Rather than monkey patching the extension, we thought this small change might be of interest for the community.

More precisely, this PR simply adds another column to the `<table>` elements defined in both the `admin/parts/_parts_table` partial and the `admin/parts/available` view, as illustrated by the following gif:

![parts_available_on](https://user-images.githubusercontent.com/4389323/95451090-9326b100-0967-11eb-8422-ccbec0d07b56.gif)
