### PR TITLE
Bump solidus_support dependency to (~> 0.5)

### DIFF
--- a/app/decorators/models/solidus_product_assembly/spree/inventory_unit_decorator.rb
+++ b/app/decorators/models/solidus_product_assembly/spree/inventory_unit_decorator.rb
@@ -2,7 +2,7 @@
 
 module SolidusProductAssembly
   module Spree
-    module InventoryUnit
+    module InventoryUnitDecorator
       def percentage_of_line_item
         product = line_item.product
         if product.assembly?

--- a/lib/solidus_product_assembly/engine.rb
+++ b/lib/solidus_product_assembly/engine.rb
@@ -4,19 +4,11 @@ require 'spree/core'
 
 module SolidusProductAssembly
   class Engine < Rails::Engine
-    include SolidusSupport::EngineExtensions::Decorators
+    include SolidusSupport::EngineExtensions
 
     isolate_namespace ::Spree
 
     engine_name 'solidus_product_assembly'
-
-    def self.activate
-      Dir.glob(File.join(File.dirname(__FILE__), "../../app/**/*_decorator.rb")) do |c|
-        Rails.configuration.cache_classes ? require(c) : load(c)
-      end
-    end
-
-    config.to_prepare &method(:activate).to_proc
 
     # use rspec for tests
     config.generators do |g|

--- a/solidus_product_assembly.gemspec
+++ b/solidus_product_assembly.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'deface'
   s.add_dependency 'solidus_core', ['>= 1.0', '< 3']
-  s.add_dependency 'solidus_support', '~> 0.4.0'
+  s.add_dependency 'solidus_support', '~> 0.5'
 
   s.add_development_dependency 'github_changelog_generator'
   s.add_development_dependency 'selenium-webdriver'


### PR DESCRIPTION
This PR is a proposal to follow the same relaxed version requirement for `solidus_support` as implemented by most other extensions.

This brings the benefit of not having to define `::activate` in _engine.rb_ to load decorators anymore.