### PR TITLE
Fixes for Views

### DIFF
--- a/app/controllers/spree/admin/parts_controller.rb
+++ b/app/controllers/spree/admin/parts_controller.rb
@@ -4,7 +4,7 @@ class Spree::Admin::PartsController < Spree::Admin::BaseController
   before_action :find_product
 
   def index
-    @parts = @product.parts
+    @parts = @product.parts.includes(:product)
   end
 
   def remove

--- a/app/views/spree/admin/products/_product_assembly_fields.html.erb
+++ b/app/views/spree/admin/products/_product_assembly_fields.html.erb
@@ -1,13 +1,16 @@
-<div class="left six columns alpha">
-  <div class="field">
-    <%= f.label :can_be_part, t('spree.can_be_part')%>
-    <%= f.check_box(:can_be_part) %>
+<div class="left col-12">
+  <div class="col">
+    <%= f.label :can_be_part do %>
+      <%= f.check_box :can_be_part %>
+      <%= t 'spree.can_be_part' %>
+    <% end %>
   </div>
-</div>
-<div class="right six columns omega">
-  <div class="field">
-    <%= f.label :individual_sale, t('spree.individual_sale')%>
-    <%= f.check_box(:individual_sale) %>
+
+  <div class="col">
+    <%= f.label :individual_sale do %>
+      <%= f.check_box :individual_sale %>
+      <%= t 'spree.individual_sale' %>
+    <% end %>
   </div>
 </div>
 

--- a/app/views/spree/admin/shared/_product_assembly_product_tabs.html.erb
+++ b/app/views/spree/admin/shared/_product_assembly_product_tabs.html.erb
@@ -1,3 +1,3 @@
-<li<%= ' class="active"' if current == "Parts" %>>
+<li class="<%= 'active' if current == 'Parts' %>">
   <%= link_to_with_icon 'sitemap', t('spree.parts'), admin_product_parts_url(@product) %>
 </li>


### PR DESCRIPTION
1. Fixes an n+1 issue on listing parts
2. Nicely lists the Can be Part and Individual Sale checkboxes
3. The tab reads `class="\"active\""` for some reason when on the page, fix is supplied for this

---

<img width="781" alt="Screen Shot 2020-12-22 at 11 42 59 AM" src="https://user-images.githubusercontent.com/3117356/102922217-ea0e3380-444a-11eb-8186-85236af5a281.png">

---

<img width="1049" alt="Screen Shot 2020-12-22 at 11 43 13 AM" src="https://user-images.githubusercontent.com/3117356/102922223-ee3a5100-444a-11eb-89f4-9f96558cfb35.png">
