### PR TITLE
Adding support for Solidus 4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,37 +11,50 @@ orbs:
   solidusio_extensions: solidusio/extensions@volatile
 
 jobs:
-  run-specs-with-postgres:
-    executor: solidusio_extensions/postgres
+  run-specs:
+    parameters:
+      solidus:
+        type: string
+        default: main
+      db:
+        type: string
+        default: "postgres"
+      ruby:
+        type: string
+        default: "3.2"
+    executor:
+      name: solidusio_extensions/<< parameters.db >>
+      ruby_version: << parameters.ruby >>
     steps:
-      - browser-tools/install-browser-tools
-      - solidusio_extensions/run-tests
-  run-specs-with-mysql:
-    executor: solidusio_extensions/mysql
-    steps:
-      - browser-tools/install-browser-tools
-      - solidusio_extensions/run-tests
-  lint-code:
-    executor: solidusio_extensions/sqlite-memory
-    steps:
-      - browser-tools/install-browser-tools
-      - solidusio_extensions/lint-code
+      - checkout
+      - solidusio_extensions/run-tests-solidus-<< parameters.solidus >>
 
 workflows:
   "Run specs on supported Solidus versions":
     jobs:
-      - run-specs-with-postgres
-      - run-specs-with-mysql
-      - lint-code
+      - run-specs:
+          name: &name "run-specs-solidus-<< matrix.solidus >>-ruby-<< matrix.ruby >>-db-<< matrix.db >>"
+          matrix:
+            parameters: { solidus: ["main"], ruby: ["3.2"], db: ["postgres"] }
+      - run-specs:
+          name: *name
+          matrix:
+            parameters: { solidus: ["current"], ruby: ["3.1"], db: ["mysql"] }
 
-  "Weekly run specs against master":
+  "Weekly run specs against main":
     triggers:
       - schedule:
           cron: "0 0 * * 4" # every Thursday
           filters:
             branches:
               only:
-                - master
+                - main
     jobs:
-      - run-specs-with-postgres
-      - run-specs-with-mysql
+      - run-specs:
+          name: *name
+          matrix:
+            parameters: { solidus: ["main"], ruby: ["3.2"], db: ["postgres"] }
+      - run-specs:
+          name: *name
+          matrix:
+            parameters: { solidus: ["current"], ruby: ["3.1"], db: ["mysql"] }

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,8 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
-solidus_git, solidus_frontend_git = if (branch == 'master') || (branch >= 'v3.2')
+branch = ENV.fetch('SOLIDUS_BRANCH', 'main')
+solidus_git, solidus_frontend_git = if (branch == 'main') || (branch >= 'v3.2')
                                       %w[solidusio/solidus solidusio/solidus_frontend]
                                     else
                                       %w[solidusio/solidus] * 2

--- a/solidus_product_assembly.gemspec
+++ b/solidus_product_assembly.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.executables = files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'solidus_core', ['>= 2.0.0', '< 4']
+  s.add_dependency 'solidus_core', ['>= 2.0.0', '< 5']
   s.add_dependency 'solidus_support', '~> 0.8'
   s.add_dependency 'deface'
 


### PR DESCRIPTION
This PR updates the gemspec for the Product Assembly gem to support Solidus 4. This hasn't been thoroughly vetted, but cursory local examination indicates that very little should be impacted here. And at least allowing users to make the choice to update to Solidus 4 seems important.