### PR TITLE
Replace Deface Ruby with DSL

### DIFF
--- a/app/overrides/add_admin_product_form_fields.rb
+++ b/app/overrides/add_admin_product_form_fields.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-Deface::Override.new(virtual_path: "spree/admin/products/_form",
-                     name: "product_assembly_admin_product_form_right",
-                     insert_after: "[data-hook='admin_product_form_right'], #admin_product_form_right[data-hook]",
-                     partial: "spree/admin/products/product_assembly_fields",
-                     disabled: false)

--- a/app/overrides/add_admin_tabs.rb
+++ b/app/overrides/add_admin_tabs.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-Deface::Override.new(virtual_path: "spree/admin/shared/_product_tabs",
-                     name: "product_assembly_admin_product_tabs",
-                     insert_bottom: "[data-hook='admin_product_tabs']",
-                     partial: "spree/admin/shared/product_assembly_product_tabs",
-                     disabled: false)

--- a/app/overrides/add_line_item_description.rb
+++ b/app/overrides/add_line_item_description.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-Deface::Override.new(virtual_path: "spree/orders/_line_item",
-                     name: "product_assembly_cart_item_description",
-                     insert_bottom: "[data-hook='cart_item_description']",
-                     partial: "spree/orders/cart_description",
-                     disabled: false)

--- a/app/overrides/spree/admin/products/_form/product_assembly_product_form_right.deface
+++ b/app/overrides/spree/admin/products/_form/product_assembly_product_form_right.deface
@@ -1,0 +1,2 @@
+insert_after "[data-hook='admin_product_form_right'], #admin_product_form_right[data-hook]"
+partial "spree/admin/products/product_assembly_fields"

--- a/app/overrides/spree/admin/shared/_product_tabs/product_assembly_admin_product_tabs.deface
+++ b/app/overrides/spree/admin/shared/_product_tabs/product_assembly_admin_product_tabs.deface
@@ -1,0 +1,2 @@
+insert_bottom "[data-hook='admin_product_tabs']"
+partial "spree/admin/shared/product_assembly_product_tabs"

--- a/app/overrides/spree/orders/_line_item/product_assembly_cart_item_description.deface
+++ b/app/overrides/spree/orders/_line_item/product_assembly_cart_item_description.deface
@@ -1,0 +1,2 @@
+insert_bottom "[data-hook='cart_item_description']"
+partial "spree/orders/cart_description"

--- a/lib/solidus_product_assembly/version.rb
+++ b/lib/solidus_product_assembly/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SolidusProductAssembly
-  VERSION = '1.3.0'
+  VERSION = '1.3.1'
 end

--- a/lib/solidus_product_assembly/version.rb
+++ b/lib/solidus_product_assembly/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SolidusProductAssembly
-  VERSION = '1.3.1'
+  VERSION = '1.3.0'
 end


### PR DESCRIPTION
This PR replaces the use of the Deface Ruby overrides with the Deface DSL. This makes this gem compatible with Rails 7.1, since the Deface overrides tend to break Zeitwerk naming conventions.