### PR TITLE
Fix uninitialized constant OpenStruct in ShipmentDecorator

### DIFF
--- a/app/decorators/models/solidus_product_assembly/spree/shipment_decorator.rb
+++ b/app/decorators/models/solidus_product_assembly/spree/shipment_decorator.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'ostruct'
 
 module SolidusProductAssembly
   module Spree


### PR DESCRIPTION
### Summary

This PR adds a `require 'ostruct'` line to `ShipmentDecorator`, which uses `OpenStruct` to build shipment item structures.

### Why this is needed

Currently, if `ostruct` is not explicitly required elsewhere in the app, Solidus will raise:

NameError: uninitialized constant SolidusProductAssembly::Spree::ShipmentDecorator::OpenStruct

This happens, for example, when rendering the delivery step in the checkout flow (`_proposed_shipment.erb` partial).

### Fix

We add a single line at the top of `shipment_decorator.rb` to ensure the required standard library is loaded.

```ruby
require 'ostruct'

### Notes

This does not impact performance and aligns with Ruby best practices. Standard library dependencies like ostruct should always be explicitly required in the file where they’re used.